### PR TITLE
pydantic-settings 2.6.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pydantic-settings" %}
-{% set version = "2.1.0" %}
+{% set version = "2.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pydantic_settings-{{ version }}.tar.gz
-  sha256: 26b1492e0a24755626ac5e6d715e9077ab7ad4fb5f19a8b7ed7011d52f36141c
+  sha256: e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -20,8 +20,13 @@ requirements:
     - pip
   run:
     - python
-    - pydantic >=2.3.0
+    - pydantic >=2.7.0
     - python-dotenv >=0.21.0
+  run_constrained:
+    - azure-identity >=1.16.0
+    - azure-keyvault-secrets >=4.8.0
+    - tomli >=2.0.1
+    - pyyaml >=6.0.1
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5773](https://anaconda.atlassian.net/browse/PKG-5773)
- [Upstream repo](https://github.com/pydantic/pydantic-settings/tree/v2.6.1)
- release-notes: https://github.com/pydantic/pydantic-settings/releases6.1
- release-diff: https://github.com/pydantic/pydantic-settings/compare/v2.1.0...v2.6.1
- license: https://github.com/pydantic/pydantic-settings/blob/main/LICENSE
- requirements-tagged:
  - https://github.com/pydantic/pydantic-settings/blob/v2.6.1/pyproject.toml
  - https://github.com/pydantic/pydantic-settings/tree/v2.6.1/requirements


### Explanation of changes:

- Remove `abs.yaml` because we're going to ship the package to the `main` channel
- Update runtime pinnings
- Add `run_constrained` with optional dependencies


### Notes:

- `anaconda-cli-base` requires it from the `main`. channel Currently, it's only in the `sfe1ed40` channel


[PKG-5773]: https://anaconda.atlassian.net/browse/PKG-5773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ